### PR TITLE
restructure directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ BINS_OUT_DIR      := $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
 build: 
 
 	$(info $(INFOMARK) Building $(CLI_BINARY) ...)
-	go build -o $(BINS_OUT_DIR)/$(CLI_BINARY) ./$(CLI_BINARY)/;
+	go build -o $(BINS_OUT_DIR)/$(CLI_BINARY);

--- a/grype/grype.go
+++ b/grype/grype.go
@@ -1,9 +1,8 @@
-package main
+package grype
 
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 
 	grypeTypes "github.com/anchore/grype/grype/presenter/models"
@@ -69,26 +68,4 @@ func (k *GrypeParser) Parse(file string) (*v1alpha1.UpdateManifest, error) {
 		}
 	}
 	return &updates, nil
-}
-
-func main() {
-	// Initialize the parser
-	grypeParser := NewGrypeParser()
-	// Get the image report from command line
-	imageReport := os.Args[1]
-
-	report, err := grypeParser.Parse(imageReport)
-	if err != nil {
-		fmt.Printf("Error scanning image: %v\n", err)
-		return
-	}
-
-	// Serialize the standardized report and print it to stdout
-	reportBytes, err := json.Marshal(report)
-	if err != nil {
-		fmt.Printf("Error serializing report: %v\n", err)
-		return
-	}
-
-	os.Stdout.Write(reportBytes)
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	copaGrype "github.com/anubhav06/copa-grype/grype"
+)
+
+func main() {
+	// Initialize the parser
+	grypeParser := copaGrype.NewGrypeParser()
+	// Get the image report from command line
+	imageReport := os.Args[1]
+
+	report, err := grypeParser.Parse(imageReport)
+	if err != nil {
+		fmt.Printf("Error scanning image: %v\n", err)
+		return
+	}
+
+	// Serialize the standardized report and print it to stdout
+	reportBytes, err := json.Marshal(report)
+	if err != nil {
+		fmt.Printf("Error serializing report: %v\n", err)
+		return
+	}
+
+	os.Stdout.Write(reportBytes)
+}


### PR DESCRIPTION
This PR moves the Grype's report parsing logic into a new package called grype, and separates the main package which is responsible for executing the code.