### PR TITLE
chore: add error handling to plugin binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ export PATH=$PATH:/path/to/copagrype/directory
 
 ## Example Usage
 ```shell
+# generate a grype report
+grype <image> -o json --file grype_report.json
+
 # test plugin with example config
 copa-grype grype_report.json
 # this will print the report in JSON format. Example:
 # {"apiVersion":"v1alpha1","metadata":{"os":{"type":"FakeOS","version":"42"},"config":{"arch":"amd64"}},"updates":[{"name":"foo","installedVersion":"1.0.0","fixedVersion":"1.0.1","vulnerabilityID":"VULN001"},{"name":"bar","installedVersion":"2.0.0","fixedVersion":"2.0.1","vulnerabilityID":"VULN002"}]}
 
+# run copa with the scanner plugin (copa-grype) and the report file
+copa patch -i $IMAGE -r grype_report.json --scanner grype
 ```

--- a/main.go
+++ b/main.go
@@ -9,6 +9,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) != 2 {
+        fmt.Fprintf(os.Stderr, "Usage: %s <image_report>\n", os.Args[0])
+        os.Exit(1)
+    }
+
 	// Initialize the parser
 	grypeParser := copaGrype.NewGrypeParser()
 	// Get the image report from command line

--- a/main.go
+++ b/main.go
@@ -21,14 +21,14 @@ func main() {
 
 	report, err := grypeParser.Parse(imageReport)
 	if err != nil {
-		fmt.Printf("Error scanning image: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error scanning image: %v\n", err)
 		return
 	}
 
 	// Serialize the standardized report and print it to stdout
 	reportBytes, err := json.Marshal(report)
 	if err != nil {
-		fmt.Printf("Error serializing report: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error serializing report: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/anubhav06/copa-grype/issues/5

This PR:
- Adds better error handling to the binary making it user friendly
- Updates README docs